### PR TITLE
Abilita export CSV

### DIFF
--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -299,6 +299,7 @@ storage.validateEvent(eventData)
 storage.validatePerson(personData)
 
 // Export dati
+// format può essere 'json' o 'csv'
 storage.exportData(format)
 
 // Import dati
@@ -437,8 +438,11 @@ Per aggiungere nuovi periodi, modifica:
 #### Export/Import
 
 ```javascript
-// Export tutti i dati
+// Export tutti i dati in JSON
 storage.exportData('json');
+
+// Export in CSV
+storage.exportData('csv');
 
 // Import da file
 const fileInput = document.getElementById('import-file');


### PR DESCRIPTION
## Summary
- support CSV format in ExportManager
- expose format select in export modal
- document available export formats

## Testing
- `node -e "require('./js/export-manager.js');"`

------
https://chatgpt.com/codex/tasks/task_e_685d340bb7408325bee0a4fc01052c1b