### PR TITLE
Fix server path handling for query params

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,10 +18,12 @@ const mimeTypes = {
 };
 
 const server = http.createServer((req, res) => {
-  let filePath = path.join(base, decodeURIComponent(req.url));
-  if (req.url === '/' || req.url === '') {
-    filePath = path.join(base, 'index.html');
+  const parsedUrl = new URL(req.url, `http://${req.headers.host}`);
+  let pathname = decodeURIComponent(parsedUrl.pathname);
+  if (pathname === '/' || pathname === '') {
+    pathname = '/index.html';
   }
+  const filePath = path.join(base, pathname);
   fs.readFile(filePath, (err, content) => {
     if (err) {
       if (err.code === 'ENOENT') {


### PR DESCRIPTION
## Summary
- parse request URLs before reading files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685d4098452c8325b0b9aab5ac56b8b0